### PR TITLE
Update Elasticsearch version to v7.10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.4
+FROM docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.0
 
 RUN bin/elasticsearch-plugin install analysis-icu

--- a/README.md
+++ b/README.md
@@ -1,20 +1,36 @@
 # elasticsearch_docker
-Contains the Elastic Search Dockerfile for Hypothesis' development environment.
 
-## Add a new docker image to the registry
-1. Build the image locally and tag it with the appropriate elastic search version.
+The Elasticsearch Dockerfile for Hypothesis' development environment.
+
+## Building the Docker image locally
+
+To build the image for just your current platform, use:
+
 ```
-docker build -t hypothesis/elasticsearch:elasticsearch6.2 .
+docker build -t hypothesis/elasticsearch:elasticsearch7.10 .
 ```
+
+To build the image for both x64 and Arm, make sure your Docker environment is
+configured to support [multi-platform
+builds](https://docs.docker.com/build/building/multi-platform/). Then run:
+
+```
+docker buildx build --platform linux/arm64/v8,linux/amd64 --tag hypothesis/elasticsearch:elasticsearch7.10 .
+```
+
+## Publishing the Docker container
+
+1. Build the container for both x64 and Arm using `docker buildx` as described
+   above.
+
 2. Login to docker hub.
-```
-docker login
-```
-3. Push the docker image to the https://hub.docker.com/r/hypothesis/elasticsearch/ docker registry.
-```
-docker push hypothesis/elasticsearch:elasticsearch6.2
-```
-4. Cleanup (optional) by deleting any unused images.
-```
-docker rmi hypothesis/elasticsearch:elasticsearch6.2
-```
+
+   ```
+   docker login
+   ```
+
+3. Push the Docker image to the registry at https://hub.docker.com/r/hypothesis/elasticsearch/.
+
+   ```
+   docker push hypothesis/elasticsearch:elasticsearch7.10
+   ```


### PR DESCRIPTION
v7.10.0 is the latest version that AWS OpenSearch supports. It is also
the version of ES that AWS OpenSearch will pretend to be if
compatibility mode is enabled.

To build locally for testing, run:

```
docker build -t hypothesis/elasticsearch:elasticsearch7.10 .
```

Related h changes: https://github.com/hypothesis/h/pull/7335